### PR TITLE
Standbyモデルのバリデーションエラーの修正

### DIFF
--- a/app/models/standby.rb
+++ b/app/models/standby.rb
@@ -6,7 +6,6 @@ class Standby < ApplicationRecord
   validates :user, presence: true
   validates :date, presence: true
   validates :start, presence:true
-  validates :break_start
   validates :break_sum, length: { maximum: 60*60*24}
 
   #standbyレコードを作成するメソッド


### PR DESCRIPTION
Standbyモデルのバリデーションに、中身の無い物が記述されていたため、削除した